### PR TITLE
현재 주차 미션 성공 챌린지원 수 조회 기능을 개발한다.(LEAR-252)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,32 @@
 ### v1.4.0 - 
 - GET v1/challenges/{challengeId}/my-good-quizzes 좋아요한 문제들 조회 API 추가
   - 내가 좋아요한 문제들의 개요 리스트를 반환한다. 수강중이거나 수강했던 챌린지가 아니라면 403 에러를 반환한다.
+- GET v1/challenges 챌린지 목록 조회 API, GET v1/my/challenges 내가 참여한 챌린지 목록 조회 API의 응답 수정
+  - <details  markdown="1">
+    <summary>ChallengeSummaryResponse 응답 DTO 세부 내용</summary>
+
+    ```
+    @Schema(description = "현재 주차 미션 성공 챌린지원 수") private int numberOfChallengerWhoCompleted;@Schema(description = "챌린지 ID") private final Long challengeId;
+    @Schema(description = "챌린지 제목") private final String title;
+    @Schema(description = "챌린지가 진행되는 주차 수") private final Integer totalWeeks;
+    @Schema(description = "주차별 최소 제출 문제 수") private final Integer minNumOfQuizzesByWeek;
+    @Schema(description = "챌린지 참가비(없으면 0)") private final Integer cost;
+    @Schema(description = "대상 대학") private final String university;
+    @Schema(description = "대상 학과") private final String department;
+    @Schema(description = "교수명") private final String professorName;
+    @Schema(description = "챌린지 기수") private final Integer chapter;
+    @Schema(description = "챌린지 대상") private final String target;
+    @Schema(description = "챌린지 시작일시") private final LocalDateTime startDate;
+    @Schema(description = "챌린지 종료일시") private final LocalDateTime endDate;
+    @Schema(description = "신청시작일시") private final LocalDateTime applicationStartDate;
+    @Schema(description = "신청종료일시") private final LocalDateTime applicationEndDate;
+    @Schema(description = "챌린지 이미지 경로") private final String imageUrl;
+    @Schema(description = "챌린지 신청 상태") private ApplicationStatus applicationStatus;
+    ```
+    </details>
+- GET v1/challenges/{challengeId} 챌린지 조회 API 응답 수정
+  - 현재 주차 미션 성공 챌린지원 수 추가
+  - ```private int numberOfChallengerWhoCompleted```
 
 
 ### v1.3.0 - 2022-09-11

--- a/src/main/java/com/kkamjidot/api/mono/config/OpenApiConfig.java
+++ b/src/main/java/com/kkamjidot/api/mono/config/OpenApiConfig.java
@@ -20,7 +20,7 @@ public class OpenApiConfig {
     public OpenAPI openAPI() {
         Info info = new Info()
                 .title("깜지. API 서버 V1")
-                .version("v1.3.0")
+                .version("v1.4.0")
                 .description("학습자료 공유 기반 챌린지 서비스 플랫폼 깜지.의 API 통합 서버 (아래 README 사이트 참고)")
                 .contact(new Contact().name("README").url("https://github.com/Learn-and-Give/com.kkamjidot.api.mono/tree/develop#readme"));
 

--- a/src/main/java/com/kkamjidot/api/mono/controller/ChallengeController.java
+++ b/src/main/java/com/kkamjidot/api/mono/controller/ChallengeController.java
@@ -2,6 +2,7 @@ package com.kkamjidot.api.mono.controller;
 
 import com.kkamjidot.api.mono.domain.User;
 import com.kkamjidot.api.mono.dto.response.ChallengeResponse;
+import com.kkamjidot.api.mono.dto.response.ChallengeSummaryResponse;
 import com.kkamjidot.api.mono.dto.response.nowResponse;
 import com.kkamjidot.api.mono.dto.response.WeekResponse;
 import com.kkamjidot.api.mono.service.UserService;
@@ -30,10 +31,10 @@ public class ChallengeController {
 
     @Operation(summary = "챌린지 목록 조회 API", description = "모든 챌린지를 조회한다.")
     @GetMapping("v1/challenges")
-    public ResponseEntity<List<ChallengeResponse>> readChallenges(@Parameter(description = "로그인한 회원 코드", example = "1234") @RequestHeader String code) {
+    public ResponseEntity<List<ChallengeSummaryResponse>> readChallenges(@Parameter(description = "로그인한 회원 코드", example = "1234") @RequestHeader String code) {
         User user = userService.authenticate(code);
 
-        List<ChallengeResponse> responses = challengeQueryService.readChallenges(user);
+        List<ChallengeSummaryResponse> responses = challengeQueryService.readChallenges(user);
 
         LOGGER.info("챌린지 목록 조회 API: Get v1/challenges [User: {}, responses: {}]", user.getId(), responses);
         return ResponseEntity.ok(responses);
@@ -53,10 +54,10 @@ public class ChallengeController {
 
     @Operation(summary = "내가 참여한 챌린지 목록 조회 API", description = "내가 참여한 챌린지 목록을 조회한다.")
     @GetMapping("v1/my/challenges")
-    public ResponseEntity<List<ChallengeResponse>> readMyChallenges(@Parameter(description = "로그인한 회원 코드", example = "1234") @RequestHeader String code) {
+    public ResponseEntity<List<ChallengeSummaryResponse>> readMyChallenges(@Parameter(description = "로그인한 회원 코드", example = "1234") @RequestHeader String code) {
         User user = userService.authenticate(code);
 
-        List<ChallengeResponse> responses = challengeQueryService.readMyChallenges(user);
+        List<ChallengeSummaryResponse> responses = challengeQueryService.readMyChallenges(user);
 
         LOGGER.info("내가 참여한 챌린지 목록 조회 API: Get v1/my/challenges [User: {}, responses: {}]", user.getId(), responses);
         return ResponseEntity.ok(responses);

--- a/src/main/java/com/kkamjidot/api/mono/controller/CommentController.java
+++ b/src/main/java/com/kkamjidot/api/mono/controller/CommentController.java
@@ -33,7 +33,6 @@ public class CommentController {
     private final Logger LOGGER = LoggerFactory.getLogger(ChallengeController.class);
 
     private final UserService userService;
-    private final CompleteService completeService;
     private final QuizService quizService;
     private final CommentService commentService;
     private final CommentQueryService commentQueryService;

--- a/src/main/java/com/kkamjidot/api/mono/controller/MissionController.java
+++ b/src/main/java/com/kkamjidot/api/mono/controller/MissionController.java
@@ -1,0 +1,23 @@
+package com.kkamjidot.api.mono.controller;
+
+import com.kkamjidot.api.mono.domain.User;
+import com.kkamjidot.api.mono.dto.response.QuizSubmissionStatusResponse;
+import com.kkamjidot.api.mono.service.CompleteService;
+import com.kkamjidot.api.mono.service.UserService;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@Hidden
+@Tag(name = "미션", description = "미션 관련 작업들")
+@RequiredArgsConstructor
+@RestController
+public class MissionController {
+}

--- a/src/main/java/com/kkamjidot/api/mono/controller/QuizController.java
+++ b/src/main/java/com/kkamjidot/api/mono/controller/QuizController.java
@@ -5,6 +5,7 @@ import com.kkamjidot.api.mono.dto.request.*;
 import com.kkamjidot.api.mono.dto.response.*;
 import com.kkamjidot.api.mono.service.*;
 import com.kkamjidot.api.mono.service.query.QuizQueryService;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -209,10 +210,13 @@ public class QuizController {
         return ResponseEntity.created(location).body(QuizIdResponse.builder().quizId(quizId).build());
     }
 
+    @Hidden
     @Operation(summary = "퀴즈 제출 현황 조회 API", description = "현재 챌린지의 퀴즈 제출 현황을 조회한다. 주차 및 챌린지원별 퀴즈 제출 횟수가 반환된다. 수강중이거나 수강했던 챌린지가 아니라면 403 에러를 반환한다.")
     @GetMapping("v1/challenges/{challengeId}/submissions-status")
-    public ResponseEntity<QuizSubmissionStatusResponse> readStatusBoard(@Parameter(description = "로그인한 회원 코드", example = "1234") @RequestHeader String code,
-                                                                        @PathVariable Long challengeId) {
+    public ResponseEntity<QuizSubmissionStatusResponse> readQuizSubmissionStatus(@Parameter(description = "로그인한 회원 코드", example = "1234") @RequestHeader String code,
+                                                                                 @PathVariable Long challengeId) {
+        User user = userService.authenticate(code);
+
         return null;
     }
 }

--- a/src/main/java/com/kkamjidot/api/mono/dto/QuizSubmissionDto.java
+++ b/src/main/java/com/kkamjidot/api/mono/dto/QuizSubmissionDto.java
@@ -1,0 +1,13 @@
+package com.kkamjidot.api.mono.dto;
+
+import lombok.Data;
+
+import java.io.Serializable;
+
+@Data
+public class QuizSubmissionDto implements Serializable {
+    Integer week;
+    Integer numberOfQuizzesSubmitted;
+    Long userId;
+    String userName;
+}

--- a/src/main/java/com/kkamjidot/api/mono/dto/response/ChallengeResponse.java
+++ b/src/main/java/com/kkamjidot/api/mono/dto/response/ChallengeResponse.java
@@ -76,11 +76,13 @@ public class ChallengeResponse implements Serializable {
     @Schema(description = "챌린지 신청 상태")
     private ApplicationStatus applicationStatus;
 
+    @Schema(description = "현재 주차 미션 성공 챌린지원 수") private int numberOfChallengerWhoCompleted;
+
     public void setApplicationStatus(ApplicationStatus status) {
         this.applicationStatus = status;
     }
 
-    public static ChallengeResponse of(Challenge challenge) {
+    public static ChallengeResponse of(Challenge challenge, int numberOfChallengerWhoCompleted) {
         ChallengeInfo challengeInfo = challenge.getChallengeInfo();
         return ChallengeResponse.builder()
                 .challengeId(challenge.getId())
@@ -102,6 +104,7 @@ public class ChallengeResponse implements Serializable {
                 .imageUrl(challengeInfo.getCinfoImageUrl())
                 .createdDate(challenge.getChallCreatedDate())
                 .modifiedDate(challenge.getChallModifiedDate())
+                .numberOfChallengerWhoCompleted(numberOfChallengerWhoCompleted)
                 .build();
     }
 }

--- a/src/main/java/com/kkamjidot/api/mono/dto/response/ChallengeSummaryResponse.java
+++ b/src/main/java/com/kkamjidot/api/mono/dto/response/ChallengeSummaryResponse.java
@@ -1,0 +1,60 @@
+package com.kkamjidot.api.mono.dto.response;
+
+import com.kkamjidot.api.mono.domain.Challenge;
+import com.kkamjidot.api.mono.domain.ChallengeInfo;
+import com.kkamjidot.api.mono.domain.enumerate.ApplicationStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@ToString
+@Getter
+@Builder
+@Schema(name = "챌린지 개요 응답")
+public class ChallengeSummaryResponse implements Serializable {
+    @Schema(description = "챌린지 ID") private final Long challengeId;
+    @Schema(description = "챌린지 제목") private final String title;
+    @Schema(description = "챌린지가 진행되는 주차 수") private final Integer totalWeeks;
+    @Schema(description = "주차별 최소 제출 문제 수") private final Integer minNumOfQuizzesByWeek;
+    @Schema(description = "챌린지 참가비(없으면 0)") private final Integer cost;
+    @Schema(description = "대상 대학") private final String university;
+    @Schema(description = "대상 학과") private final String department;
+    @Schema(description = "교수명") private final String professorName;
+    @Schema(description = "챌린지 기수") private final Integer chapter;
+    @Schema(description = "챌린지 대상") private final String target;
+    @Schema(description = "챌린지 시작일시") private final LocalDateTime startDate;
+    @Schema(description = "챌린지 종료일시") private final LocalDateTime endDate;
+    @Schema(description = "신청시작일시") private final LocalDateTime applicationStartDate;
+    @Schema(description = "신청종료일시") private final LocalDateTime applicationEndDate;
+    @Schema(description = "챌린지 이미지 경로") private final String imageUrl;
+    @Schema(description = "챌린지 신청 상태") private ApplicationStatus applicationStatus;
+
+    public void setApplicationStatus(ApplicationStatus status) {
+        this.applicationStatus = status;
+    }
+
+    public static ChallengeSummaryResponse of(Challenge challenge) {
+        ChallengeInfo challengeInfo = challenge.getChallengeInfo();
+        return ChallengeSummaryResponse.builder()
+                .challengeId(challenge.getId())
+                .title(challengeInfo.getCinfoTitle())
+                .totalWeeks(challenge.getChallTotalWeeks())
+                .minNumOfQuizzesByWeek(challenge.getChallMinNumOfQuizzesByWeek())
+                .cost(challenge.getChallCost())
+                .university(challengeInfo.getCinfoUniversity())
+                .department(challengeInfo.getCinfoDepartment())
+                .professorName(challengeInfo.getCinfoProfessorName())
+                .chapter(challenge.getChallChapter())
+                .target(challenge.getChallTarget())
+                .startDate(challenge.getChallStartDate())
+                .endDate(challenge.getChallEndDate())
+                .applicationStartDate(challenge.getChallApplicationStartDate())
+                .applicationEndDate(challenge.getChallApplicationEndDate())
+                .imageUrl(challengeInfo.getCinfoImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/kkamjidot/api/mono/dto/response/CountCompletedResponse.java
+++ b/src/main/java/com/kkamjidot/api/mono/dto/response/CountCompletedResponse.java
@@ -1,0 +1,10 @@
+package com.kkamjidot.api.mono.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.io.Serializable;
+
+@Schema(description = "현재 주차 미션 성공 챌린지원 수")
+public class CountCompletedResponse implements Serializable {
+    int count;
+}

--- a/src/main/java/com/kkamjidot/api/mono/dto/response/QuizSubmissionStatusResponse.java
+++ b/src/main/java/com/kkamjidot/api/mono/dto/response/QuizSubmissionStatusResponse.java
@@ -1,24 +1,110 @@
 package com.kkamjidot.api.mono.dto.response;
 
-import com.kkamjidot.api.mono.dto.UserDto;
+import com.kkamjidot.api.mono.domain.Challenge;
+import com.kkamjidot.api.mono.domain.Complete;
+import com.kkamjidot.api.mono.domain.User;
+import com.kkamjidot.api.mono.dto.QuizSubmissionDto;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 import lombok.Data;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
+import java.util.Objects;
 
 @Data
+@Builder
 @Schema(name = "퀴즈 제출 현황 응답")
 public class QuizSubmissionStatusResponse implements Serializable {
-    private List<UserDto> userList;
+    @Schema(description = "챌린지 ID") private Long challengeId;
     @Schema(description = "챌린지가 진행되는 주차 수") private Integer totalWeeks;
-    @Schema(description = "Map<주차, 주차별 퀴즈 제출 현황>") private Map<Integer, QuizSubmissionStatusByWeek> quizSubmissionStatusByWeek;
+    @Schema(description = "유저별 퀴즈 제출 현황 리스트") private List<QuizSubmissionStatusByUser> quizSubmissionStatusByUser;
 
     @Data
-    @Schema(description = "주차별 퀴즈 제출 현황")
-    static class QuizSubmissionStatusByWeek implements Serializable {
-        @Schema(description = "Map<유저 ID, 제출 수>") private Map<Long, Integer> numberOfQuizzesSubmittedByUserId;
-        @Schema(description = "최다 제출 수") private Integer mostNumberOfQuizzesSubmitted;
+    @Builder
+    @Schema(description = "유저별 퀴즈 제출 현황")
+    static class QuizSubmissionStatusByUser implements Serializable {
+        @Schema(description = "유저 ID") private Long userId;
+        @Schema(description = "유저 이름") private String userName;
+        @Schema(description = "주차별 퀴즈 제출 수 리스트") private List<NumberOfQuizzesSubmittedByWeek> numberOfQuizzesSubmittedByWeek;
+    }
+
+    @Data
+    @Builder
+    @Schema(description = "주차별 퀴즈 제출 수")
+    static class NumberOfQuizzesSubmittedByWeek implements Serializable {
+        @Schema(description = "주차") private Integer week;
+        @Schema(description = "퀴즈 제출 수") private Integer numberOfQuizzesSubmitted;
+        @Schema(description = "미션 완료 여부") private Boolean isCompleted;
+        @Schema(description = "왕관 여부") private Boolean isTakenCrown;
+    }
+
+    static QuizSubmissionStatusResponse of(Challenge challenge, List<User> challengers, List<QuizSubmissionDto> quizSubmissionDtoList, List<Complete> completes) {
+        List<QuizSubmissionStatusByUser> quizSubmissionStatusByUser = new ArrayList<>();
+
+        // 주차별 최고 퀴즈 제출 수
+        int[] maxNumberOfQuizzesSubmittedByWeek = new int[challenge.getChallTotalWeeks()];
+        for (QuizSubmissionDto quizSubmissionDto : quizSubmissionDtoList) {
+            if (maxNumberOfQuizzesSubmittedByWeek[quizSubmissionDto.getWeek() - 1] < quizSubmissionDto.getNumberOfQuizzesSubmitted()) {
+                maxNumberOfQuizzesSubmittedByWeek[quizSubmissionDto.getWeek() - 1] = quizSubmissionDto.getNumberOfQuizzesSubmitted();
+            }
+        }
+
+        // 응답 객체 생성
+        for (User user : challengers) {
+            List<NumberOfQuizzesSubmittedByWeek> numberOfQuizzesSubmittedByWeek = new ArrayList<>();
+            quizSubmissionDtoList.stream()
+                    .filter(quizSubmissionDto -> Objects.equals(quizSubmissionDto.getUserId(), user.getId()))
+                    .forEach(quizSubmissionDto -> {
+                        numberOfQuizzesSubmittedByWeek.add(NumberOfQuizzesSubmittedByWeek.builder()
+                                .week(quizSubmissionDto.getWeek())
+                                .numberOfQuizzesSubmitted(quizSubmissionDto.getNumberOfQuizzesSubmitted())
+                                .isCompleted(completes.stream().anyMatch(complete -> Objects.equals(complete.getUser().getId(), user.getId())
+                                                                                     && Objects.equals(complete.getWeek(), quizSubmissionDto.getWeek())))
+                                .isTakenCrown(quizSubmissionDto.getNumberOfQuizzesSubmitted() > challenge.getChallMinNumOfQuizzesByWeek()
+                                              && maxNumberOfQuizzesSubmittedByWeek[quizSubmissionDto.getWeek() - 1] == quizSubmissionDto.getNumberOfQuizzesSubmitted())
+                                .build());
+
+                    });
+
+            quizSubmissionStatusByUser.add(QuizSubmissionStatusByUser.builder()
+                    .userId(user.getId())
+                    .userName(user.getUserName())
+                    .numberOfQuizzesSubmittedByWeek(numberOfQuizzesSubmittedByWeek)
+                    .build());
+        }
+
+        return QuizSubmissionStatusResponse.builder()
+                .challengeId(challenge.getId())
+                .totalWeeks(challenge.getChallTotalWeeks())
+                .quizSubmissionStatusByUser(quizSubmissionStatusByUser)
+                .build();
     }
 }
+/*
+{
+    "challengeId": 1,
+    "totalWeeks": 14,
+    "quizSubmissionStatusByUser": [
+        {
+            "userId": 1,
+            "userName": "John Doe",
+            "numberOfQuizzesSubmittedByWeek": [
+                {
+                    "week": 1,
+                    "numberOfQuizzesSubmitted": 3,
+                    "isCompleted": true,
+                    "isTakenCrown": true
+                },
+                {
+                    "week": 2,
+                    "numberOfQuizzesSubmitted": 0,
+                    "isCompleted": false,
+                    "isTakenCrown": false
+                }
+            ]
+        }
+    ]
+}
+ */

--- a/src/main/java/com/kkamjidot/api/mono/repository/CompleteRepository.java
+++ b/src/main/java/com/kkamjidot/api/mono/repository/CompleteRepository.java
@@ -10,4 +10,5 @@ import java.util.List;
 public interface CompleteRepository extends JpaRepository<Complete, Long> {
     List<Complete> findByUserAndChall(User user, Challenge chall);
     boolean existsByWeekAndUserAndChall(Integer week, User user, Challenge chall);
+    int countByChallAndWeek(Challenge challenge, Integer week);
 }

--- a/src/main/java/com/kkamjidot/api/mono/service/CompleteService.java
+++ b/src/main/java/com/kkamjidot/api/mono/service/CompleteService.java
@@ -49,4 +49,8 @@ public class CompleteService {
     public List<Integer> findCompleteWeeks(User user, Challenge challenge) {
         return completeRepository.findByUserAndChall(user, challenge).stream().map(Complete::getWeek).toList();  // 열람 가능 주차 조회
     }
+
+    public int countComplete(Challenge challenge) {
+        return completeRepository.countByChallAndWeek(challenge, challenge.getNowWeek());
+    }
 }

--- a/src/main/java/com/kkamjidot/api/mono/service/query/ChallengeQueryService.java
+++ b/src/main/java/com/kkamjidot/api/mono/service/query/ChallengeQueryService.java
@@ -5,6 +5,7 @@ import com.kkamjidot.api.mono.domain.TakeAClass;
 import com.kkamjidot.api.mono.domain.User;
 import com.kkamjidot.api.mono.domain.enumerate.ApplicationStatus;
 import com.kkamjidot.api.mono.dto.response.ChallengeResponse;
+import com.kkamjidot.api.mono.dto.response.ChallengeSummaryResponse;
 import com.kkamjidot.api.mono.dto.response.WeekResponse;
 import com.kkamjidot.api.mono.dto.response.enumerate.WeekStatus;
 import com.kkamjidot.api.mono.dto.response.nowResponse;
@@ -29,25 +30,25 @@ public class ChallengeQueryService {
     private final CompleteService completeService;
     private final ChallengeService challengeService;
 
-    public List<ChallengeResponse> readChallenges(User user) {
+    public List<ChallengeSummaryResponse> readChallenges(User user) {
         // 챌린지 목록 조회
         List<Challenge> challenges = challengeRepository.findByChallDeletedDateNull();
 
         // 응답 객체 생성
-        List<ChallengeResponse> challengeResponses = new ArrayList<>(challenges.size());
+        List<ChallengeSummaryResponse> challengeSummaryResponses = new ArrayList<>(challenges.size());
         for (Challenge challenge : challenges) {
-            ChallengeResponse challengeResponse = ChallengeResponse.of(challenge);
-            findApplicationStatus(challenge, user).ifPresent(challengeResponse::setApplicationStatus);     // 신청상태
-            challengeResponses.add(challengeResponse);
+            ChallengeSummaryResponse challengeSummaryResponse = ChallengeSummaryResponse.of(challenge);
+            findApplicationStatus(challenge, user).ifPresent(challengeSummaryResponse::setApplicationStatus);     // 신청상태
+            challengeSummaryResponses.add(challengeSummaryResponse);
         }
 
-        return challengeResponses;
+        return challengeSummaryResponses;
     }
 
     public ChallengeResponse readChallenge(Long challengeId, User user) {
         // 챌린지 조회
         Challenge challenge = challengeService.findOne(challengeId);
-        ChallengeResponse challengeResponse = ChallengeResponse.of(challenge);
+        ChallengeResponse challengeResponse = ChallengeResponse.of(challenge, completeService.countComplete(challenge));
         findApplicationStatus(challenge, user).ifPresent(challengeResponse::setApplicationStatus);     // 신청상태
         return challengeResponse;
     }
@@ -56,19 +57,19 @@ public class ChallengeQueryService {
         return takeAClassRepository.findByChallAndUser(challenge, user).map(TakeAClass::getTcApplicationstatus);
     }
 
-    public List<ChallengeResponse> readMyChallenges(User user) {
+    public List<ChallengeSummaryResponse> readMyChallenges(User user) {
         // 수강 목록 조회
         List<TakeAClass> takes = takeAClassRepository.findByUser(user);
 
         // 응답 객체 생성
-        List<ChallengeResponse> challengeResponses = new ArrayList<>(takes.size());
+        List<ChallengeSummaryResponse> challengeSummaryResponses = new ArrayList<>(takes.size());
         for (TakeAClass take : takes) {
-            ChallengeResponse challengeResponse = ChallengeResponse.of(take.getChall());
-            challengeResponse.setApplicationStatus(take.getTcApplicationstatus());
-            challengeResponses.add(challengeResponse);
+            ChallengeSummaryResponse challengeSummaryResponse = ChallengeSummaryResponse.of(take.getChall());
+            challengeSummaryResponse.setApplicationStatus(take.getTcApplicationstatus());
+            challengeSummaryResponses.add(challengeSummaryResponse);
         }
 
-        return challengeResponses;
+        return challengeSummaryResponses;
     }
 
     public WeekResponse readWeeks(Long challengeId, User user) {

--- a/src/main/java/com/kkamjidot/api/mono/service/query/QuizQueryService.java
+++ b/src/main/java/com/kkamjidot/api/mono/service/query/QuizQueryService.java
@@ -105,4 +105,10 @@ public class QuizQueryService {
     public Solve findSolve(Long quizId, User user) {
         return solveRepository.findByQuiz_IdAndUserAndSolveAnswerNotNull(quizId, user).orElseThrow(() -> new UnauthorizedException("아직 풀지 않았습니다."));
     }
+
+    public QuizSubmissionStatusResponse readQuizSubmissionStatus(User user, Long challengeId) {
+        Challenge challenge = challengeService.findOne(challengeId);
+
+        return null;
+    }
 }


### PR DESCRIPTION
개요
- 현재 주차 미션 성공 챌린지원 수를 챌린지 조회 API에서 같이 반환해준다.

명세
- ```@Schema(description = "현재 주차 미션 성공 챌린지원 수") private int numberOfChallengerWhoCompleted;```

개발
- 챌린지와 챌린지 개요를 분리한다.

- GET v1/challenges 챌린지 목록 조회 API, GET v1/my/challenges 내가 참여한 챌린지 목록 조회 API의 응답 수정
- ```
	@Schema(description = "현재 주차 미션 성공 챌린지원 수") private int numberOfChallengerWhoCompleted;@Schema(description = "챌린지 ID") private final Long challengeId;
	@Schema(description = "챌린지 제목") private final String title;
	@Schema(description = "챌린지가 진행되는 주차 수") private final Integer totalWeeks;
	@Schema(description = "주차별 최소 제출 문제 수") private final Integer minNumOfQuizzesByWeek;
	@Schema(description = "챌린지 참가비(없으면 0)") private final Integer cost;
	@Schema(description = "대상 대학") private final String university;
	@Schema(description = "대상 학과") private final String department;
	@Schema(description = "교수명") private final String professorName;
	@Schema(description = "챌린지 기수") private final Integer chapter;
	@Schema(description = "챌린지 대상") private final String target;
	@Schema(description = "챌린지 시작일시") private final LocalDateTime startDate;
	@Schema(description = "챌린지 종료일시") private final LocalDateTime endDate;
	@Schema(description = "신청시작일시") private final LocalDateTime applicationStartDate;
	@Schema(description = "신청종료일시") private final LocalDateTime applicationEndDate;
	@Schema(description = "챌린지 이미지 경로") private final String imageUrl;
	@Schema(description = "챌린지 신청 상태") private ApplicationStatus applicationStatus;
	```
- 챌린지 조회에 현재 주차 미션 성공 챌린지원 수를 추가한다.
	- GET v1/challenges/{challengeId} 챌린지 조회 API 응답 수정
		- 현재 주차 미션 성공 챌린지원 수 추가
		- private int numberOfChallengerWhoCompleted